### PR TITLE
inferno: fixed central nibbler determination

### DIFF
--- a/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoPlugin.java
+++ b/inferno/src/main/java/net/runelite/client/plugins/inferno/InfernoPlugin.java
@@ -858,6 +858,14 @@ public class InfernoPlugin extends Plugin
 				|| (amountInArea == bestAmountInArea && distanceToPlayer < bestDistanceToPlayer))
 			{
 				bestNibbler = infernoNPC;
+
+				// if just the bestDistanceToPlayer has improved, this statement will do nothing
+				bestAmountInArea = amountInArea; 
+
+				if (distanceToPlayer < bestDistanceToPlayer)
+				{
+					bestDistanceToPlayer = distanceToPlayer;
+				}
 			}
 		}
 


### PR DESCRIPTION
Fixed the central nibbler code by getting it to update the current "best" nibbler counts, and distances to the player, so accurate comparisons occur.